### PR TITLE
Add EC2 RDS permissions policies

### DIFF
--- a/infra/policies/CustompolicyEC2
+++ b/infra/policies/CustompolicyEC2
@@ -1,0 +1,61 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
+                "ec2:DescribeKeyPairs",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeImages"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:RunInstances",
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestTag/Name": "flask-app-dev"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:TerminateInstances"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:ResourceTag/Name": "flask-app-dev"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupEgress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
+                "ec2:ImportKeyPair"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/infra/policies/CustompolicyRDS
+++ b/infra/policies/CustompolicyRDS
@@ -1,0 +1,37 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:CreateDBInstance",
+                "rds:DeleteDBInstance",
+                "rds:ModifyDBInstance",
+                "rds:DescribeDBInstances",
+                "rds:CreateDBSecurityGroup",
+                "rds:DeleteDBSecurityGroup",
+                "rds:AuthorizeDBSecurityGroupIngress",
+                "rds:RevokeDBSecurityGroupIngress",
+                "rds:CreateDBSubnetGroup",
+                "rds:DeleteDBSubnetGroup",
+                "rds:DescribeDBSubnetGroups",
+                "rds:DescribeDBEngineVersions",
+                "rds:ListTagsForResource"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource"
+            ],
+            "Resource": "arn:aws:rds:*:*:db:*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestTag/Name": "flaskappdb"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Custom Policies with minimum permissions to run Jenkins Pipeline. These are independent policies cause these could change with the additions of new segments, just like it did with ansible.